### PR TITLE
Fix mounts for unpredictable device mappings

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -18,8 +18,10 @@ define(NERVES_FW_PLATFORM, "x86_64")
 define(NERVES_FW_ARCHITECTURE, "x86_64")
 define(NERVES_FW_AUTHOR, "Frank Hunleth")
 
-define(NERVES_FW_DEVPATH, "/dev/sda")
-define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/sda3") # Linux part number is 1-based
+# /dev/rootdisk* paths are provided by erlinit to refer to the disk and partitions
+# on whatever drive provides the rootfs.
+define(NERVES_FW_DEVPATH, "/dev/rootdisk0")
+define(NERVES_FW_APPLICATION_PART0_DEVPATH, "/dev/rootdisk4") # Linux part number is 1-based
 define(NERVES_FW_APPLICATION_PART0_FSTYPE, "ext4")
 define(NERVES_FW_APPLICATION_PART0_TARGET, "/root")
 
@@ -184,7 +186,7 @@ task complete {
 
       # Invalidate the application data partition so that it is guaranteed to
       # trigger the corrupt filesystem detection code on first boot and get
-        # formatted.
+      # formatted.
       raw_memset(${APP_PART_OFFSET}, 256, 0xff)
     }
 }
@@ -192,7 +194,7 @@ task complete {
 task upgrade.a {
     # This task upgrades the A partition, so make sure we're running
     # on B.
-    require-path-on-device("/", "/dev/sda3")
+    require-uboot-variable(uboot-env, "nerves_fw_active", "b")
 
     # Verify the expected platform/architecture
     require-uboot-variable(uboot-env, "b.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
@@ -240,7 +242,7 @@ task upgrade.a {
 task upgrade.b {
     # This task upgrades the B partition, so make sure we're running
     # on A.
-    require-path-on-device("/", "/dev/sda2")
+    require-uboot-variable(uboot-env, "nerves_fw_active", "a")
 
     # Verify the expected platform/architecture
     require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
@@ -288,7 +290,7 @@ task upgrade.wrong {
     require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
     require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
     on-init {
-        error("Please check that the rootfs is on /dev/sdaX")
+        error("Please check that the nerves_fw_active metadata variable")
     }
 }
 

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -20,7 +20,7 @@
 #--gid 200
 
 # Uncomment to hang the board rather than rebooting when Erlang exits
-# NOTE: Do not enable on production boards
+# NOTE: Do not enable on production releases
 #--hang-on-exit
 
 # Change the graceful shutdown time. If 10 seconds isn't long enough between
@@ -35,7 +35,7 @@
 -e LANG=en_US.UTF-8;LANGUAGE=en;ERL_INETRC=/etc/erl_inetrc;ERL_CRASH_DUMP=/root/crash.dump
 
 # Mount the application partition
--m /dev/sda3:/root:ext4::
+-m /dev/rootdisk4:/root:ext4::
 
 # Erlang release search path
 -r /srv/erlang

--- a/rootfs_overlay/etc/fw_env.config
+++ b/rootfs_overlay/etc/fw_env.config
@@ -6,4 +6,4 @@
 # See fwup.conf for offset and size
 
 # Device name	Device offset	Env. size	Flash sector size	Number of sectors
-/dev/sda	0x100000	0x2000		0x200			16
+/dev/rootdisk0	0x100000	0x2000		0x200			16


### PR DESCRIPTION
This renames references to sda to rootdisk so that the right drives are
mapped on systems that have unpredictable device mappings. This happens
on x86 systems where a USB flash drive can also be mapped to sda and
it's random whether it gets mapped there or sdb on boot.