### PR TITLE
Optimize circle ci configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
   environment:
     ENV: CI
     MIX_ENV: test
-    ELIXIR_VERSION: 1.6.4
+    ELIXIR_VERSION: 1.6.5
 
 install_elixir: &install_elixir
   run:
@@ -28,6 +28,29 @@ install_nerves_bootstrap: &install_nerves_bootstrap
     command: |
       mix archive.install hex nerves_bootstrap "~> 1.0" --force
 
+install_aws_cli: &install_aws_cli
+  run:
+    name: Install AWS CLI
+    command : |
+      apt update -qq
+      apt install awscli -qq -y
+
+install_ghr: &install_ghr
+  run:
+    name: Install ghr (Github Releases)
+    command: |
+      wget https://github.com/tcnksm/ghr/releases/download/v0.9.0/ghr_v0.9.0_linux_amd64.tar.gz
+      tar xf ghr_v0.9.0_linux_amd64.tar.gz
+      ln -sf ghr_v0.9.0_linux_amd64/ghr .
+
+sync_dl_cache: &sync_dl_cache
+  run: 
+    name: Sync downloads cache
+    command: |
+      set +e
+      aws s3 sync ~/.nerves/dl s3://nerves-project/dl
+      exit 0
+
 version: 2.0
 
 jobs:
@@ -41,27 +64,27 @@ jobs:
       - run:
           name: Install dependencies
           command: mix deps.get
-      - restore_cache:
-          key: nerves/cache-{{ .Environment.CIRCLE_PROJECT_USERNAME}}-{{ .Environment.CIRCLE_PROJECT_REPONAME}}
       - run:
           name: Build
           command: mix compile
       - run:
+          name: Did I really build
+          command: |
+            [ -d /nerves/build/.nerves ] || (echo "VERSION file needs to be bumped or a config file needs to change to force a build"; exit 1)
+      - run:
           name: Lint
           command: mix nerves.system.lint nerves_defconfig
-      - save_cache:
-          key: nerves/dl-{{ .Environment.CIRCLE_PROJECT_USERNAME}}-{{ .Environment.CIRCLE_PROJECT_REPONAME}}
-          paths:
-            - "/nerves/dl"
+      - <<: *install_aws_cli
+      - <<: *sync_dl_cache
       - run:
-          name: "Create artifact dir"
+          name: Create artifact dir
           command: mkdir -p /nerves/deploy/system/artifacts
       - run:
-          name: "Copy CHANGELOG"
+          name: Copy CHANGELOG
           command: cp ./CHANGELOG.md /nerves/deploy/system/CHANGELOG.md
 
       - run:
-          name: "Create artifacts"
+          name: Create artifacts
           command: |
             if [ -n "$CIRCLE_TAG" ]; then
               TAG=$CIRCLE_TAG
@@ -73,41 +96,41 @@ jobs:
           path: /nerves/deploy/system/artifacts
           destination: system
       - save_cache:
-          key: nerves/build-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
-          paths:
-            - "/nerves/build"
-      - save_cache:
           key: nerves/deploy/system-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
           paths:
             - "/nerves/deploy/system"
 
   build_test:
     <<: *defaults
-    artifacts:
-      - "/nerves/build/test/_build/test/nerves/images/"
-    working_directory: /nerves/build/test
     steps:
+      - checkout
       - restore_cache:
-          key: nerves/build-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+          key: nerves/deploy/system-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - run:
+          name: Copy artifacts
+          command: |
+            mkdir -p ~/.nerves/dl
+            cp /nerves/deploy/system/artifacts/*.gz ~/.nerves/dl
       - <<: *install_elixir
       - <<: *install_hex_rebar
       - <<: *install_nerves_bootstrap
       - run:
-          name: Create Nerves paths
-          command: mkdir -p ~/.nerves/artifacts
-      - run:
           name: Install test dependencies
-          command: mix deps.get
+          command: |
+            cd test
+            mix deps.get
       - run:
           name: Create test firmware
-          command: mix firmware
+          command: |
+            cd test
+            mix firmware
       - run:
-          name: "Create artifact dir"
+          name: Create artifact dir
           command: mkdir -p /nerves/deploy/test/artifacts
       - run:
           name: Create build context
           command: >
-            mix json.encode
+            cd test && mix json.encode
             /nerves/deploy/test/artifacts/${CIRCLE_SHA1}.json
             --sha $CIRCLE_SHA1
             --repo-org $CIRCLE_PROJECT_USERNAME
@@ -119,7 +142,7 @@ jobs:
             --ci-build-url $CIRCLE_BUILD_URL
             --ci-build-num $CIRCLE_BUILD_NUM
       - run:
-          name: "Sign test fw artifact"
+          name: Sign test fw artifact
           command: fwup --sign --private-key $NERVES_FW_PRIV_KEY -i /nerves/build/test/_build/test/nerves/images/test.fw -o /nerves/deploy/test/artifacts/${CIRCLE_SHA1}.fw
       - store_artifacts:
           path: /nerves/deploy/test/artifacts
@@ -132,11 +155,7 @@ jobs:
   deploy_test:
     <<: *defaults
     steps:
-      - run:
-          name: Install dependencies
-          command: |
-            apt-get update
-            apt-get -y install awscli
+      - <<: *install_aws_cli
       - restore_cache:
           key: nerves/deploy/test-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
       - deploy:
@@ -148,14 +167,10 @@ jobs:
     steps:
       - restore_cache:
           key: nerves/deploy/system-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+      - <<: *install_ghr
       - run:
-          name: Install dependencies
-          command: |
-            wget https://github.com/tcnksm/ghr/releases/download/v0.5.4/ghr_v0.5.4_linux_amd64.zip
-            unzip ghr_v0.5.4_linux_amd64.zip
-      - run:
-          name: "Create Release Notes"
-          command: grep -Pazo "(?s)(?<=## ${CIRCLE_TAG})[^#]+" /nerves/deploy/system/CHANGELOG.md > /nerves/deploy/system/RELEASE_NOTES
+          name: Create release notes
+          command: grep -Pazo "(?s)(?<=## ${CIRCLE_TAG})[^#]+" /nerves/deploy/system/CHANGELOG.md | sed '/./,$!d' > /nerves/deploy/system/RELEASE_NOTES
       - run:
           name: Deploy artifacts to Github
           command: ./ghr -draft -t $GITHUB_TOKEN -u $CIRCLE_PROJECT_USERNAME -r $CIRCLE_PROJECT_REPONAME -b "$(cat /nerves/deploy/system/RELEASE_NOTES)" -replace $CIRCLE_TAG /nerves/deploy/system/artifacts


### PR DESCRIPTION
This PR updates the configuration for CircleCI with portions not in active discussion from https://github.com/nerves-project/nerves_system_rpi3/pull/51

* Fix inconsistencies with syntax
* Update version of `ghr` to v0.9.0
* Remove build directory caching. 

Currently, the build directory is being added to a circle ci cache to be shared with the build_test job. It takes quite a while to package up the build directory. Instead of sharing the build directory, we switch to unpacking the already cached artifacts into the build_test job containers` NERVES_DL_DIR`.