### PR TITLE
Move boardid configuration out of erlinit.config

### DIFF
--- a/rootfs_overlay/etc/boardid.config
+++ b/rootfs_overlay/etc/boardid.config
@@ -1,0 +1,7 @@
+# boardid.config
+
+# Read the serial number from the U-boot environment block.
+-b uboot_env -u nerves_serial_number
+
+# Use the MAC address of the first Ethernet port.
+-b macaddr -n 4

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -51,10 +51,9 @@
 # Erlang release search path
 -r /srv/erlang
 
-# Assign a hostname of the form "nerves-<serial_number>". The serial number is either
-# read from the U-boot environment block that contains provisioning information from
-# manufacturing or it uses 4 digits of the Ethernet adapter's MAC address
--d "/usr/bin/boardid -b uboot_env -u nerves_serial_number -b uboot_env -u serial_number -b macaddr -n 4"
+# Assign a hostname of the form "nerves-<serial_number>".
+# See /etc/boardid.config for locating the serial number.
+-d /usr/bin/boardid
 -n nerves-%s
 
 # If using shoehorn (https://github.com/nerves-project/shoehorn), start the


### PR DESCRIPTION
This makes it possible to call "boardid" from anywhere and get the
intended ID.