### PR TITLE
Set expand=true on application partition

### DIFF
--- a/fwup-revert.conf
+++ b/fwup-revert.conf
@@ -98,33 +98,6 @@ file-resource grubenv_b {
     host-path = "${NERVES_SYSTEM}/images/grubenv_b"
 }
 
-mbr mbr {
-    bootstrap-code-host-path = "${NERVES_SYSTEM}/images/boot.img"
-    signature = 0x04030201
-
-    partition 0 {
-        block-offset = ${BOOT_PART_OFFSET}
-        block-count = ${BOOT_PART_COUNT}
-        type = 0xc # FAT32
-        boot = true
-    }
-    partition 1 {
-        block-offset = ${ROOTFS_A_PART_OFFSET}
-        block-count = ${ROOTFS_A_PART_COUNT}
-        type = 0x83 # Linux
-    }
-    partition 2 {
-        block-offset = ${ROOTFS_B_PART_OFFSET}
-        block-count = ${ROOTFS_B_PART_COUNT}
-        type = 0x83 # Linux
-    }
-    partition 3 {
-        block-offset = ${APP_PART_OFFSET}
-        block-count = ${APP_PART_COUNT}
-        type = 0x83 # Linux
-    }
-}
-
 # Location where installed firmware information is stored.
 # While this is called "u-boot", u-boot isn't involved in this
 # setup. It just provides a convenient key/value store format.

--- a/fwup.conf
+++ b/fwup.conf
@@ -134,6 +134,7 @@ mbr mbr {
         block-offset = ${APP_PART_OFFSET}
         block-count = ${APP_PART_COUNT}
         type = 0x83 # Linux
+        expand = true
     }
 }
 


### PR DESCRIPTION
This enlarges the application partition to fill the destination when
programming MicroSD, etc. for the first time. Users wanting to enlarge
application partitions in devices in the field will need to do more work
since fwup doesn't know how to expand filesystem data structures.

Devices with fwup versions before 1.3.0 (Feb 2019) will ignore the
expand flag.

Erase the mbr section in the fwup-revert.conf since it's unused.