### PR TITLE
Enable delta update support

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -226,6 +226,8 @@ task upgrade.a {
     }
 
     on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_B_PART_COUNT}
         raw_write(${ROOTFS_A_PART_OFFSET})
     }
 
@@ -277,6 +279,8 @@ task upgrade.b {
     }
 
     on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_A_PART_COUNT}
         raw_write(${ROOTFS_B_PART_OFFSET})
     }
 


### PR DESCRIPTION
This adds the information needed to the fwup.conf to support delta
updates. This is only one piece of delta update support. NervesHub can
automatically generate and distribute delta updates so long as it has a
copy of a device's firmware (a source firmware image) and the device is
running a version of fwup (1.6.0 or later; this is in nerves_system_br
1.11.2/May 2020 and later) that supports delta updates.