### PR TITLE
Fix toolchain selection to use Nerves toolchain

### DIFF
--- a/nerves_defconfig
+++ b/nerves_defconfig
@@ -6,6 +6,7 @@ BR2_OPTIMIZE_2=y
 BR2_GLOBAL_PATCH_DIR="${BR2_EXTERNAL_NERVES_PATH}/patches"
 BR2_REPRODUCIBLE=y
 BR2_TOOLCHAIN_EXTERNAL=y
+BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
 BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
 BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/nerves-project/toolchains/releases/download/v1.6.0/nerves_toolchain_x86_64_nerves_linux_musl-linux_x86_64-1.6.0-63239A0.tar.xz"
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM_PREFIX="$(ARCH)-nerves-linux-musl"


### PR DESCRIPTION
The Buildroot 2022.05 update requires one more configuration to use the
toolchain parameters in the `nerves_defconfig`. Without it, the default
external gcc 11.2-based glibc toolchain was used instead. Most things
worked, but any C programs compiled with elixir_make would not. Those
programs rightfully refered to the muslc-supplied dynamic loader with
didn't exist in the Nerves system since it had the glibc-supplied
dynamic loader.
