### PR TITLE
Switch the console to the virtual serial port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ probably will require some work.
 | Memory               | 512 MB+ DRAM                    |
 | Storage              | Hard disk/SSD/etc. (/dev/sda)   |
 | Linux kernel         | 6.6                             |
-| IEx terminal         | Display - tty0                  |
+| IEx terminal         | Virtual serial - ttyS0          |
 | Hardware I/O         | None                            |
 | Ethernet             | Yes                             |
 

--- a/grub.cfg
+++ b/grub.cfg
@@ -13,10 +13,10 @@ load_env
 # Boot A or B depending on which one is active
 if [ $boot = 1 ]; then
      echo "Booting partition B..."
-     linux (hd0,msdos3)/boot/bzImage root=PARTUUID=04030201-03 rootwait console=tty1
+     linux (hd0,msdos3)/boot/bzImage root=PARTUUID=04030201-03 rootwait console=tty1 console=ttyS0
 else
      echo "Booting partition A..."
-     linux (hd0,msdos2)/boot/bzImage root=PARTUUID=04030201-02 rootwait console=tty1
+     linux (hd0,msdos2)/boot/bzImage root=PARTUUID=04030201-02 rootwait console=tty1 console=ttyS0
 fi
 
 # Boot!!!

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -9,7 +9,7 @@
 
 # Specify where erlinit should send the IEx prompt. Only one may be enabled at
 # a time.
--c tty1   # Output console
+-c ttyS0   # Serial console
 
 # If more than one tty are available, always warn if the user is looking at the
 # wrong one.


### PR DESCRIPTION
This allows you to run qemu images headless in a shell terminal. Without
this change, you need to be able to open a GTK window on Linux. Probably
similar things are needed on Windows and MacOS.
