### PR TITLE
Add AWS role to enable pushing Buildroot package downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,8 @@ jobs:
           otp-version: ${{ env.OTP_VERSION }}
           elixir-version: ${{ env.ELIXIR_VERSION }}
           nerves-bootstrap-version: ${{ env.NERVES_BOOTSTRAP_VERSION }}
-          push-to-download-site: false
-          download-site-url: ${{ vars.PUBLIC_S3_SITE }}
-          download-site-bucket-uri: ${{ vars.S3_BUCKET }}
+          push-to-download-site: true
+          download-site-bucket-uri: ${{ vars.DOWNLOAD_SITE_BUCKET_URI }}
           aws-role: ${{ secrets.AWS_ROLE }}
           aws-region: ${{ vars.AWS_REGION }}
   build-system:


### PR DESCRIPTION
With the switch to GitHub Actions we disabled the push of Buildroot downloads to the cache bucket. We now have a role setup and are turning it back on in order to capture packages for ease of download.

The `get-br-dependencies` job succeeds including the upload of artifacts. But the build job fails because only CI config has changed and the check for "did we change and should we build" fails